### PR TITLE
fix: resolve black box overlay on .user-mention elements

### DIFF
--- a/content.css
+++ b/content.css
@@ -57,6 +57,20 @@
   cursor: help;
 }
 
+/* user-mention 元素特殊处理 - 隐藏 gnm 的 tooltip 伪元素以避免黑色方形框 */
+.user-mention.gnm-replaced::after {
+  content: '' !important;
+  background: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+}
+
+.user-mention.gnm-replaced::before {
+  content: '' !important;
+  border: none !important;
+}
+
 /* ==================== 头像高亮样式 ==================== */
 
 /* 头像高亮 - 使用多重样式确保可见性 */


### PR DESCRIPTION
## 修复内容

修复开启插件后 `.user-mention` 元素（如 @用户名）上出现黑色方框遮挡正文的问题。

## 问题原因

`.gnm-replaced::after` 伪元素的 `content: attr(title)` 与 GitHub 原生 `.user-mention` 样式冲突，导致显示黑色方形框。

## 解决方案

为 `.user-mention.gnm-replaced` 添加特殊处理：
- 使用 `content: ''` 清空伪元素内容
- 重置 background、border、box-shadow、padding 等视觉样式

Fixes #2